### PR TITLE
add extension flag param

### DIFF
--- a/anddown/jni/anddown.c
+++ b/anddown/jni/anddown.c
@@ -22,7 +22,7 @@
 #define OUTPUT_UNIT 64
 
 JNIEXPORT jstring JNICALL Java_com_commonsware_cwac_anddown_AndDown_markdownToHtml
-  (JNIEnv *env, jobject o, jstring raw) {
+  (JNIEnv *env, jobject o, jstring raw, jint flag) {
   struct hoedown_buffer *ib, *ob;
   jstring result;
   hoedown_renderer *renderer;
@@ -38,7 +38,7 @@ JNIEXPORT jstring JNICALL Java_com_commonsware_cwac_anddown_AndDown_markdownToHt
   (*env)->ReleaseStringUTFChars(env, raw, str);
 
   renderer = hoedown_html_renderer_new(0, 0);
-  document = hoedown_document_new(renderer, 0, 16);
+  document = hoedown_document_new(renderer, flag, 16);
 
   hoedown_document_render(document, ob, ib->data, ib->size);
   hoedown_document_free(document);

--- a/anddown/jni/com_commonsware_cwac_anddown_AndDown.h
+++ b/anddown/jni/com_commonsware_cwac_anddown_AndDown.h
@@ -13,7 +13,7 @@ extern "C" {
  * Signature: (Ljava/lang/String;)Ljava/lang/String;
  */
 JNIEXPORT jstring JNICALL Java_com_commonsware_cwac_anddown_AndDown_markdown
-  (JNIEnv *, jobject, jstring);
+  (JNIEnv *, jobject, jstring, jint);
 
 #ifdef __cplusplus
 }

--- a/anddown/src/com/commonsware/cwac/anddown/AndDown.java
+++ b/anddown/src/com/commonsware/cwac/anddown/AndDown.java
@@ -5,5 +5,52 @@ public class AndDown {
     System.loadLibrary("anddown");
   }
 
-  public native String markdownToHtml(String raw);
+  // extension flags for markdown rendering (see document.h for detail)
+  // no extensions
+  public static final int FLAG_EXTENSIONS_NONE = 0;
+  // basic extensions set: tables(bit 0), autolink(bit 3), strike through(bit 4), underline(bit 5)
+  public static final int FLAG_EXTENSIONS_BASIC = 0x39;
+  // medium extensions set: fenced code(bit 1), highlight(bit 6), quote(bit 7), superscript(bit 8)
+  public static final int FLAG_EXTENSIONS_MEDIUM = FLAG_EXTENSIONS_BASIC | 0x1c2;
+  // advance extensions set: footnotes(bit 2), math(bit 9)
+  public static final int FLAG_EXTENSIONS_ADVANCE = FLAG_EXTENSIONS_MEDIUM | 0x204;
+
+  static final int[] EXTENSIONS_LEVEL = {
+    FLAG_EXTENSIONS_NONE,
+    FLAG_EXTENSIONS_BASIC,
+    FLAG_EXTENSIONS_MEDIUM,
+    FLAG_EXTENSIONS_ADVANCE,
+  };
+
+  // Disable emphasis_between_words(bit 11)
+  public static final int FLAG_NO_INTRA_EMPHASIS = 1 << 11;
+  // Require a space after '#' in headers(bit 12)
+  public static final int FLAG_SPACE_HEADERS = 1 << 12;
+  // Instead of guessing by context, parse $inline math$ and $$always block math$$(bit 13)
+  public static final int FLAG_MATH_EXPLICIT = 1 << 13;
+  // Don't parse indented code blocks(bit 14)
+  public static final int FLAG_DISABLE_INDENTED_CODE = 1 << 14;
+
+  // default flag for markdown rendering
+  public static final int FLAG_DEFAULT = FLAG_EXTENSIONS_NONE;
+
+  public native String markdownToHtml(String raw, int flag);
+
+  public String markdownToHtml(String raw) {
+    return markdownToHtml(raw, FLAG_DEFAULT);
+  }
+
+  /**
+   * convent markdown to html
+   *
+   * @raw: markdown in plain text
+   * @flag: extension flags for markdown rendering
+   * @level: 0 - none, 1 - basic, 2 - medium, 3 - advance, other value are ignored
+   */
+  public String markdownToHtml(String raw, int flag, int level) {
+    if (level >= 0 && level < EXTENSIONS_LEVEL.length) {
+      flag |= EXTENSIONS_LEVEL[level];
+    }
+    return markdownToHtml(raw, flag);
+  }
 }


### PR DESCRIPTION
now `markdownToHtml()` is able to render extra markdown syntax supported by [hoedown](https://github.com/hoedown/hoedown)
